### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,39 @@
+# Each line is a file pattern followed by one or more owners. Being an owner
+# means those groups or individuals will be added as reviewers to PRs affecting
+# those areas of the code.
+#
+# More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+/.github/ @xpdota
+
+# Tanks
+/pld/ @amakiirs
+/war/ @ElAtiendeBoludos @Moxfi @Vantablak
+/drk/ @VioletStardustXIV @amakiirs @aPileofCats
+/gnb/ @kromuluss
+
+# Healers
+/whm/ @xpdota @ShyShys @symphonicabyss1
+/sch/ @xpdota @ShyShys @symphonicabyss1
+/ast/ @xpdota @ShyShys @symphonicabyss1
+/sge/ @xpdota @ShyShys @symphonicabyss1
+
+# Melee
+/mnk/
+/drg/
+/nin/
+/sam/
+/rpr/
+/vpr/
+
+# Physical Ranged
+/brd/
+/mch/
+/dnc/
+
+# Casters
+/blm/
+/smn/
+/rdm/
+/pct/
+/blu/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,15 +8,15 @@
 
 # Tanks
 /pld/ @amakiirs
-/war/ @ElAtiendeBoludos @Moxfi @Vantablak
-/drk/ @VioletStardustXIV @amakiirs @aPileofCats
-/gnb/ @kromuluss
+/war/ @ElAtiendeBoludos @Vantablak
+/drk/ @VioletStardustXIV @amakiirs
+/gnb/ 
 
 # Healers
-/whm/ @xpdota @ShyShys @symphonicabyss1
-/sch/ @xpdota @ShyShys @symphonicabyss1
-/ast/ @xpdota @ShyShys @symphonicabyss1
-/sge/ @xpdota @ShyShys @symphonicabyss1
+/whm/ @xpdota @symphonicabyss1
+/sch/ @xpdota @symphonicabyss1
+/ast/ @xpdota @symphonicabyss1
+/sge/ @xpdota @symphonicabyss1
 
 # Melee
 /mnk/


### PR DESCRIPTION
I think this looks good. I added all the jobs, even those that don't use static bis now, so it's easier to add in the future. Easy enough to iterate on.

It only allows you to add users with write access to the repo, but this will allow greater right access, hopefully.

Not sure if requiring code owner approval is a repo permission.
