### PR TITLE
Add github token to use

### DIFF
--- a/.github/workflows/approve_prs.yaml
+++ b/.github/workflows/approve_prs.yaml
@@ -41,3 +41,5 @@ jobs:
           permission: write  
       - name: Approve pull request
         uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
>  Error: Unprocessable Entity: "GitHub Actions is not permitted to approve pull requests.". This typically happens when you try to approve the pull request with the same user account that created the pull request. Try using the built-in `${{ secrets.GITHUB_TOKEN }}` token, or if you're using a personal access token, use one that belongs to a dedicated bot account.